### PR TITLE
fix: correctly get the paper size on Win3

### DIFF
--- a/wordpvw.h
+++ b/wordpvw.h
@@ -49,6 +49,7 @@ public:
 	virtual void OnPrint(CDC* pDC, CPrintInfo* pInfo);
 	//}}AFX_VIRTUAL
 	BOOL OnPreparePrinting(CPrintInfo* pInfo);
+	virtual void OnPrinterChanged(const CDC& dcPrinter);
 	virtual HRESULT GetClipboardData(CHARRANGE* lpchrg, DWORD reco,
 		LPDATAOBJECT lpRichDataObj, LPDATAOBJECT* lplpdataobj);
 	virtual HRESULT QueryAcceptData(LPDATAOBJECT, CLIPFORMAT*, DWORD,


### PR DESCRIPTION
Win3 lacks `GetDeviceCaps(PHYSICALWIDTH)` and `GetDeviceCaps(PHYSICALHEIGHT)`, which are used by `CRichEdit::OnPrinterChanged()`, so these values must be obtained from `Escape(GETPHYSPAGESIZE)` instead.

Closes #5.